### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/gen_ecc.yml
+++ b/.github/workflows/gen_ecc.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish to Github Package Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           dockerfile: Dockerfile
           name: docker.pkg.github.com/sauci/pyecc/pyecc


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore